### PR TITLE
Added a check for ensuring the .ssh directory exists.

### DIFF
--- a/aws-ssm-ec2-proxy-command.sh
+++ b/aws-ssm-ec2-proxy-command.sh
@@ -51,7 +51,7 @@ aws ssm send-command \
   --document-name 'AWS-RunShellScript' \
   --comment "Add an SSH public key to authorized_keys for 60 seconds" \
   --parameters commands="\"
-    [ -f ~/${ssh_user}/.ssh ] || mkdir -p ~/${ssh_user}/.ssh
+    mkdir -p ~/${ssh_user}/.ssh
     cd ~/${ssh_user}/.ssh || exit 1
     authorized_key='${ssh_public_key} ssm-session'
     echo \\\"\${authorized_key}\\\" >> authorized_keys

--- a/aws-ssm-ec2-proxy-command.sh
+++ b/aws-ssm-ec2-proxy-command.sh
@@ -51,7 +51,8 @@ aws ssm send-command \
   --document-name 'AWS-RunShellScript' \
   --comment "Add an SSH public key to authorized_keys for 60 seconds" \
   --parameters commands="\"
-    cd ~${ssh_user}/.ssh || exit 1
+    [ -f ~/${ssh_user}/.ssh ] || mkdir -p ~/${ssh_user}/.ssh
+    cd ~/${ssh_user}/.ssh || exit 1
     authorized_key='${ssh_public_key} ssm-session'
     echo \\\"\${authorized_key}\\\" >> authorized_keys
     sleep 60


### PR DESCRIPTION
When connecting to SSM the first time after instance creation, the connections fail because the .ssh directory does not yet exist for the ssm-user.