### PR TITLE
Update aws-ssm-ec2-proxy-command.sh

### DIFF
--- a/aws-ssm-ec2-proxy-command.sh
+++ b/aws-ssm-ec2-proxy-command.sh
@@ -46,13 +46,13 @@ then
   ec2_instance_id="${ec2_instance_id%%${REGION_SEPARATOR}*}"
 fi
 
->/dev/stderr echo "Add public key ${ssh_public_key_path} to instance ${ec2_instance_id} for 60 seconds"
+>/dev/stderr echo "Add public key ${ssh_public_key} at path ${ssh_public_key_path} to instance ${ec2_instance_id} as ${ssh_user} for ${ssh_public_key_timeout} seconds"
 aws ssm send-command \
   --instance-ids "${ec2_instance_id}" \
   --document-name 'AWS-RunShellScript' \
   --comment "Add an SSH public key to authorized_keys for ${ssh_public_key_timeout} seconds" \
   --parameters commands="\"
-    mkdir -p ~${ssh_user}/.ssh && cd \$_ || exit 1
+    mkdir -p /home/${ssh_user}/.ssh && cd /home/${ssh_user}/.ssh || exit 1
     
     authorized_key='${ssh_public_key} ssm-session'
     echo \\\"\${authorized_key}\\\" >> authorized_keys


### PR DESCRIPTION
I could not make the original script work with the simple command expansion `$_` and worse it failed silently (and as I am admin I happened to have the root private key for all the instances on my ssh-add keychain so we could not figure out why devs could not access it but I could). 

I changed it to this to a less elegant but working solution for ubuntu/centos/fedora etc but obviously there might need to be an alternative solution for distros that do not use `/home/` for user directories.