### PR TITLE
Fix(windows): remove space character

### DIFF
--- a/ec2-instance-connect/aws-ssm-ec2-proxy-command.ps1
+++ b/ec2-instance-connect/aws-ssm-ec2-proxy-command.ps1
@@ -13,7 +13,7 @@
 # Add following SSH Config Entry to ~/.ssh/config
 #   host i-* mi-*
 #     IdentityFile ~/.ssh/id_rsa
-#     ProxyCommand powershell .exe ~/.ssh/aws-ssm-ec2-proxy-command.ps1 %h %r %p ~/.ssh/id_rsa.pub
+#     ProxyCommand powershell.exe ~/.ssh/aws-ssm-ec2-proxy-command.ps1 %h %r %p ~/.ssh/id_rsa.pub
 #     StrictHostKeyChecking no
 #
 # Ensure SSM Permissions for Target Instance Profile


### PR DESCRIPTION
Couldn't figure out why it wasn't working till I double checked my config. Cross checked with the readme and noticed that space isn't meant to be there.